### PR TITLE
Add support for handlebars block comments in Ember configuration

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -5,6 +5,7 @@ schema_version = 1
 authors = ["James Lamont <james@getvero.com>"]
 description = "Syntax Highlighting for Ember"
 repository = "https://github.com/jylamont/zed-ember"
+block_comment = ["{{!-- ", " --}}"]
 
 [grammars.glimmer]
 repository = "https://github.com/ember-tooling/tree-sitter-glimmer"

--- a/extension.toml
+++ b/extension.toml
@@ -5,7 +5,6 @@ schema_version = 1
 authors = ["James Lamont <james@getvero.com>"]
 description = "Syntax Highlighting for Ember"
 repository = "https://github.com/jylamont/zed-ember"
-block_comment = ["{{!-- ", " --}}"]
 
 [grammars.glimmer]
 repository = "https://github.com/ember-tooling/tree-sitter-glimmer"

--- a/languages/glimmer/config.toml
+++ b/languages/glimmer/config.toml
@@ -1,3 +1,4 @@
 name = "Handlebars"
 grammar = "glimmer"
 path_suffixes = ["hbs"]
+block_comment = ["{{!-- ", " --}}"]


### PR DESCRIPTION
Since the ember extension is adding support for handlebars templates, I would enjoy having support for block comments in those as well.