### PR TITLE
Implement support for gts and gjs syntax highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+#
+# zed-vue
+#
+
+*.wasm
+grammars/
+
+#
+# Rust
+#
+
+/target

--- a/extension.toml
+++ b/extension.toml
@@ -9,3 +9,11 @@ repository = "https://github.com/jylamont/zed-ember"
 [grammars.glimmer]
 repository = "https://github.com/ember-tooling/tree-sitter-glimmer"
 commit = "6b25d265c990139353e1f7f97baf84987ebb7bf0"
+
+[grammars.glimmer_typescript]
+repository = "https://github.com/NullVoxPopuli/tree-sitter-glimmer-typescript"
+commit = "48c60295f1ee34ea4ed6e5177102be6d24bfc9d0"
+
+[grammars.glimmer_javascript]
+repository = "https://github.com/NullVoxPopuli/tree-sitter-glimmer-javascript"
+commit = "babba3fc0c822a633261ce9e96a4d7986050eb0c"

--- a/languages/glimmer_javascript/brackets.scm
+++ b/languages/glimmer_javascript/brackets.scm
@@ -1,0 +1,15 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)
+("<" @open ">" @close)
+("\"" @open "\"" @close)
+("'" @open "'" @close)
+("`" @open "`" @close)
+
+("</" @open ">" @close)
+(
+  (glimmer_template
+    (glimmer_opening_tag) @open
+    (glimmer_closing_tag) @close
+  ) (#set! newline.only)
+)

--- a/languages/glimmer_javascript/config.toml
+++ b/languages/glimmer_javascript/config.toml
@@ -1,0 +1,25 @@
+name = "Glimmer (JavaScript)"
+grammar = "glimmer_javascript"
+path_suffixes = ["gjs"]
+line_comments = ["// "]
+autoclose_before = ";:.,=}])>"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = false, newline = true, not_in = ["comment", "string"] },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "`", end = "`", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] },
+]
+word_characters = ["$", "#"]
+prettier_plugins = ["prettier-plugin-ember-template-tag"]
+prettier_parser_name = "ember-template-tag"
+tab_size = 2
+
+[jsx_tag_auto_close]
+open_tag_node_name = "glimmer_opening_tag"
+close_tag_node_name = "glimmer_closing_tag"
+tag_name_node_name = "glimmer_template_tag_name"
+jsx_element_node_name = "glimmer_template"

--- a/languages/glimmer_javascript/embedding.scm
+++ b/languages/glimmer_javascript/embedding.scm
@@ -1,0 +1,73 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/javascript
+
+(
+    (comment)* @context
+    .
+    [
+        (export_statement
+            (function_declaration
+                "async"? @name
+                "function" @name
+                name: (_) @name))
+        (function_declaration
+            "async"? @name
+            "function" @name
+            name: (_) @name)
+    ] @item
+)
+
+(
+    (comment)* @context
+    .
+    [
+        (export_statement
+            (class_declaration
+                "class" @name
+                name: (_) @name))
+        (class_declaration
+            "class" @name
+            name: (_) @name)
+    ] @item
+)
+
+;(
+;    (comment)* @context
+;    .
+;    [
+;        (export_statement
+;            (interface_declaration
+;                "interface" @name
+;                name: (_) @name))
+;        (interface_declaration
+;            "interface" @name
+;            name: (_) @name)
+;    ] @item
+;)
+
+;(
+;    (comment)* @context
+;    .
+;    [
+;        (export_statement
+;            (enum_declaration
+;                "enum" @name
+;                name: (_) @name))
+;        (enum_declaration
+;            "enum" @name
+;            name: (_) @name)
+;    ] @item
+;)
+
+(
+    (comment)* @context
+    .
+    (method_definition
+        [
+            "get"
+            "set"
+            "async"
+            "*"
+            "static"
+            ]* @name
+        name: (_) @name) @item
+)

--- a/languages/glimmer_javascript/highlights.scm
+++ b/languages/glimmer_javascript/highlights.scm
@@ -1,0 +1,242 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/javascript
+; Variables
+
+(identifier) @variable
+
+; Properties
+
+(property_identifier) @property
+(shorthand_property_identifier) @property
+(shorthand_property_identifier_pattern) @property
+
+; Function and method calls
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @function.method))
+
+; Function and method definitions
+
+(function_expression
+  name: (identifier) @function)
+(function_declaration
+  name: (identifier) @function)
+(method_definition
+  name: (property_identifier) @function.method)
+(method_definition
+    name: (property_identifier) @constructor
+    (#eq? @constructor "constructor"))
+
+(pair
+  key: (property_identifier) @function.method
+  value: [(function_expression) (arrow_function)])
+
+(assignment_expression
+  left: (member_expression
+    property: (property_identifier) @function.method)
+  right: [(function_expression) (arrow_function)])
+
+(variable_declarator
+  name: (identifier) @function
+  value: [(function_expression) (arrow_function)])
+
+(assignment_expression
+  left: (identifier) @function
+  right: [(function_expression) (arrow_function)])
+
+; Special identifiers
+
+; ((identifier) @type
+; (#match? @type "^[A-Z]"))
+;(type_identifier) @type
+;(predefined_type) @type.builtin
+
+([
+  (identifier)
+  (shorthand_property_identifier)
+  (shorthand_property_identifier_pattern)
+ ] @constant
+ (#match? @constant "^_*[A-Z_][A-Z\\d_]*$"))
+
+; Literals
+
+(this) @variable.special
+(super) @variable.special
+
+[
+  (null)
+  (undefined)
+] @constant.builtin
+
+[
+  (true)
+  (false)
+] @boolean
+
+(comment) @comment
+
+[
+  (string)
+  (template_string)
+] @string
+
+(escape_sequence) @string.escape
+
+(regex) @string.regex
+(regex_flags) @keyword.regex
+(number) @number
+
+; Tokens
+
+[
+  ";"
+;  "?."
+  "."
+  ","
+  ":"
+] @punctuation.delimiter
+
+[
+  "-"
+  "--"
+  "-="
+  "+"
+  "++"
+  "+="
+  "*"
+  "*="
+  "**"
+  "**="
+  "/"
+  "/="
+  "%"
+  "%="
+  "<"
+  "<="
+  "<<"
+  "<<="
+  "="
+  "=="
+  "==="
+  "!"
+  "!="
+  "!=="
+  "=>"
+  ">"
+  ">="
+  ">>"
+  ">>="
+  ">>>"
+  ">>>="
+  "~"
+  "^"
+  "&"
+  "|"
+  "^="
+  "&="
+  "|="
+  "&&"
+  "||"
+  "??"
+  "&&="
+  "||="
+  "??="
+] @operator
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+
+(ternary_expression
+  [
+    "?"
+    ":"
+  ] @operator
+)
+
+[
+  "as"
+  "async"
+  "await"
+  "break"
+  "case"
+  "catch"
+  "class"
+  "const"
+  "continue"
+  "debugger"
+  "default"
+  "delete"
+  "do"
+  "else"
+  "export"
+  "extends"
+  "finally"
+  "for"
+  "from"
+  "function"
+  "get"
+  "if"
+  "import"
+  "in"
+  "instanceof"
+  "let"
+  "new"
+  "of"
+  "return"
+  "set"
+  "static"
+  "switch"
+  "target"
+  "throw"
+  "try"
+  "typeof"
+;  "using"
+  "var"
+  "void"
+  "while"
+  "with"
+  "yield"
+] @keyword
+
+(template_substitution
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+;(type_arguments
+;  "<" @punctuation.bracket
+;  ">" @punctuation.bracket)
+
+(decorator "@" @punctuation.special)
+
+; Keywords
+
+[
+;  "abstract"
+;  "declare"
+;  "enum"
+  "export"
+;  "implements"
+;  "interface"
+;  "keyof"
+;  "namespace"
+;  "private"
+;  "protected"
+;  "public"
+;  "type"
+;  "readonly"
+;  "override"
+] @keyword
+
+(glimmer_opening_tag) @tag
+(glimmer_closing_tag) @tag
+
+(glimmer_template) ["<" "</" ">"] @punctuation.bracket

--- a/languages/glimmer_javascript/indents.scm
+++ b/languages/glimmer_javascript/indents.scm
@@ -1,0 +1,27 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/javascript
+[
+    (call_expression)
+    (assignment_expression)
+    (member_expression)
+    (lexical_declaration)
+    (variable_declaration)
+    (assignment_expression)
+    (if_statement)
+    (for_statement)
+] @indent
+
+(_ "[" "]" @end) @indent
+(_ "<" ">" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent
+
+; (jsx_opening_element ">" @end) @indent
+
+; (jsx_element
+;  (jsx_opening_element) @start
+;  (jsx_closing_element)? @end) @indent
+
+(glimmer_template
+  (glimmer_opening_tag)
+  (glimmer_closing_tag) @end
+) @indent

--- a/languages/glimmer_javascript/injections.scm
+++ b/languages/glimmer_javascript/injections.scm
@@ -1,0 +1,76 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/javascript
+(((comment) @_jsdoc_comment
+  (#match? @_jsdoc_comment "(?s)^/[*][*][^*].*[*]/$")) @injection.content
+  (#set! injection.language "jsdoc"))
+
+((regex) @injection.content
+  (#set! injection.language "regex"))
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "css")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "css"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "html")
+  arguments: (template_string) @injection.content
+                              (#set! injection.language "html")
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "js")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "javascript"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "json")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "json"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "sql")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "sql"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "ts")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "typescript"))
+)
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^ya?ml$")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "yaml"))
+)
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^g(raph)?ql$")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "graphql"))
+)
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^g(raph)?ql$")
+  arguments: (arguments (template_string (string_fragment) @injection.content
+                              (#set! injection.language "graphql")))
+)
+
+; Parse Ember/Glimmer/Handlebars/HTMLBars/etc. template literals
+; e.g.: await render(hbs`<SomeComponent />`)
+(call_expression
+  function: ((identifier) @_name
+    (#eq? @_name "hbs"))
+  arguments: (template_string
+      (string_fragment) @injection.content
+      (#set! injection.language "Handlebars")))
+
+; Ember Unified <template> syntax
+; e.g.: <template><SomeComponent @arg={{double @value}} /></template>
+((glimmer_template
+  (raw_text) @injection.content)
+  (#set! injection.language "Handlebars"))

--- a/languages/glimmer_javascript/outline.scm
+++ b/languages/glimmer_javascript/outline.scm
@@ -1,0 +1,90 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/javascript
+;(internal_module
+;    "namespace" @context
+;    name: (_) @name) @item
+
+;(enum_declaration
+;    "enum" @context
+;    name: (_) @name) @item
+
+(function_declaration
+    "async"? @context
+    "function" @context
+    name: (_) @name
+    parameters: (formal_parameters
+      "(" @context
+      ")" @context)) @item
+
+;(interface_declaration
+;    "interface" @context
+;    name: (_) @name) @item
+
+(program
+    (export_statement
+        (lexical_declaration
+            ["let" "const"] @context
+            (variable_declarator
+                name: (_) @name) @item)))
+
+(program
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (_) @name) @item))
+
+(class_declaration
+    "class" @context
+    name: (_) @name) @item
+
+(method_definition
+    [
+        "get"
+        "set"
+        "async"
+        "*"
+;        "readonly"
+        "static"
+;        (override_modifier)
+;        (accessibility_modifier)
+    ]* @context
+    name: (_) @name
+    parameters: (formal_parameters
+      "(" @context
+      ")" @context)) @item
+
+;(public_field_definition
+;    [
+;        "declare"
+;        "readonly"
+;        "abstract"
+;        "static"
+;        (accessibility_modifier)
+;    ]* @context
+;    name: (_) @name) @item
+
+; Add support for (node:test, bun:test and Jest) runnable
+(
+    (call_expression
+        function: [
+            (identifier) @_name
+            (member_expression
+                object: [
+                    (identifier) @_name
+                    (member_expression object: (identifier) @_name)
+                ]
+            )
+        ] @context
+        (#any-of? @_name "it" "test" "describe" "context" "suite")
+        arguments: (
+            arguments . (string (string_fragment) @name)
+        )
+    )
+) @item
+
+(comment) @annotation
+
+(class_body
+  (glimmer_template
+    (glimmer_opening_tag) @name
+  ) @item
+)

--- a/languages/glimmer_javascript/overrides.scm
+++ b/languages/glimmer_javascript/overrides.scm
@@ -1,0 +1,16 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/javascript
+(comment) @comment.inclusive
+
+[
+  (string)
+  (template_string)
+] @string
+
+; (jsx_element) @element
+
+; [
+;   (jsx_opening_element)
+;   (jsx_closing_element)
+;   (jsx_self_closing_element)
+;   (jsx_expression)
+; ] @default

--- a/languages/glimmer_javascript/runnables.scm
+++ b/languages/glimmer_javascript/runnables.scm
@@ -1,0 +1,22 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/javascript
+; Add support for (node:test, bun:test and Jest) runnable
+; Function expression that has `it`, `test` or `describe` as the function name
+(
+    (call_expression
+        function: [
+            (identifier) @_name
+            (member_expression
+                object: [
+                    (identifier) @_name
+                    (member_expression object: (identifier) @_name)
+                ]
+            )
+        ]
+        (#any-of? @_name "it" "test" "describe" "context" "suite" "module")
+        arguments: (
+            arguments . (string (string_fragment) @run)
+        )
+    ) @_js-test
+
+    (#set! tag js-test)
+)

--- a/languages/glimmer_javascript/textobjects.scm
+++ b/languages/glimmer_javascript/textobjects.scm
@@ -1,0 +1,52 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/javascript
+(comment)+ @comment.around
+
+(function_declaration
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(method_definition
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(function_expression
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(arrow_function
+    body: (statement_block
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(arrow_function) @function.around
+
+(generator_function
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(generator_function_declaration
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(class_declaration
+    body: (_
+        "{"
+        [(_) ";"?]* @class.inside
+        "}" )) @class.around
+
+(class
+    body: (_
+        "{"
+        [(_) ";"?]* @class.inside
+        "}" )) @class.around

--- a/languages/glimmer_typescript/brackets.scm
+++ b/languages/glimmer_typescript/brackets.scm
@@ -1,0 +1,16 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/typescript
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)
+("<" @open ">" @close)
+("\"" @open "\"" @close)
+("'" @open "'" @close)
+("`" @open "`" @close)
+
+("</" @open ">" @close)
+(
+  (glimmer_template
+    (glimmer_opening_tag) @open
+    (glimmer_closing_tag) @close
+  ) (#set! newline.only)
+)

--- a/languages/glimmer_typescript/config.toml
+++ b/languages/glimmer_typescript/config.toml
@@ -1,0 +1,25 @@
+name = "Glimmer (TypeScript)"
+grammar = "glimmer_typescript"
+path_suffixes = ["gts"]
+line_comments = ["// "]
+autoclose_before = ";:.,=}])>"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "(", end = ")", close = true, newline = true },
+    { start = "<", end = ">", close = false, newline = true, not_in = ["string", "comment"] },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
+    { start = "`", end = "`", close = true, newline = false, not_in = ["string"] },
+    { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
+]
+word_characters = ["#", "$"]
+prettier_plugins = ["prettier-plugin-ember-template-tag"]
+prettier_parser_name = "ember-template-tag"
+tab_size = 2
+
+[jsx_tag_auto_close]
+open_tag_node_name = "glimmer_opening_tag"
+close_tag_node_name = "glimmer_closing_tag"
+tag_name_node_name = "glimmer_template_tag_name"
+jsx_element_node_name = "glimmer_template"

--- a/languages/glimmer_typescript/embedding.scm
+++ b/languages/glimmer_typescript/embedding.scm
@@ -1,0 +1,86 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/typescript
+(
+    (comment)* @context
+    .
+    [
+        (export_statement
+            (function_declaration
+                "async"? @name
+                "function" @name
+                name: (_) @name))
+        (function_declaration
+            "async"? @name
+            "function" @name
+            name: (_) @name)
+    ] @item
+)
+
+(
+    (comment)* @context
+    .
+    [
+        (export_statement
+            (class_declaration
+                "class" @name
+                name: (_) @name))
+        (class_declaration
+            "class" @name
+            name: (_) @name)
+    ] @item
+)
+
+(
+    (comment)* @context
+    .
+    [
+        (export_statement
+            (interface_declaration
+                "interface" @name
+                name: (_) @name))
+        (interface_declaration
+            "interface" @name
+            name: (_) @name)
+    ] @item
+)
+
+(
+    (comment)* @context
+    .
+    [
+        (export_statement
+            (enum_declaration
+                "enum" @name
+                name: (_) @name))
+        (enum_declaration
+            "enum" @name
+            name: (_) @name)
+    ] @item
+)
+
+(
+    (comment)* @context
+    .
+    [
+        (export_statement
+            (type_alias_declaration
+                "type" @name
+                name: (_) @name))
+        (type_alias_declaration
+            "type" @name
+            name: (_) @name)
+    ] @item
+)
+
+(
+    (comment)* @context
+    .
+    (method_definition
+        [
+            "get"
+            "set"
+            "async"
+            "*"
+            "static"
+            ]* @name
+        name: (_) @name) @item
+)

--- a/languages/glimmer_typescript/highlights.scm
+++ b/languages/glimmer_typescript/highlights.scm
@@ -1,0 +1,275 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/typescript
+; Variables
+
+(identifier) @variable
+
+; Special identifiers
+
+((identifier) @type
+ (#match? @type "^[A-Z]"))
+(type_identifier) @type
+(predefined_type) @type.builtin
+
+(import_specifier
+  "type"
+  name: (identifier) @type
+  alias: (identifier) @type
+)
+
+(import_statement
+  "type"
+  (import_clause
+    (named_imports
+      (import_specifier
+        name: (identifier) @type
+        alias: (identifier) @type
+      )
+    )
+  )
+)
+
+([
+  (identifier)
+  (shorthand_property_identifier)
+  (shorthand_property_identifier_pattern)
+ ] @constant
+ (#match? @constant "^_*[A-Z_][A-Z\\d_]*$"))
+
+; Properties
+
+(property_identifier) @property
+(shorthand_property_identifier) @property
+(shorthand_property_identifier_pattern) @property
+
+; Function and method calls
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @function.method))
+
+; Function and method definitions
+
+(function_expression
+  name: (identifier) @function)
+(function_declaration
+  name: (identifier) @function)
+(method_definition
+  name: (property_identifier) @function.method)
+(method_definition
+    name: (property_identifier) @constructor
+    (#eq? @constructor "constructor"))
+
+(pair
+  key: (property_identifier) @function.method
+  value: [(function_expression) (arrow_function)])
+
+(assignment_expression
+  left: (member_expression
+    property: (property_identifier) @function.method)
+  right: [(function_expression) (arrow_function)])
+
+(variable_declarator
+  name: (identifier) @function
+  value: [(function_expression) (arrow_function)])
+
+(assignment_expression
+  left: (identifier) @function
+  right: [(function_expression) (arrow_function)])
+
+; Literals
+
+(this) @variable.special
+(super) @variable.special
+
+[
+  (null)
+  (undefined)
+] @constant.builtin
+
+[
+  (true)
+  (false)
+] @boolean
+
+(literal_type
+  [
+    (null)
+    (undefined)
+    (true)
+    (false)
+  ] @type.builtin
+)
+
+(comment) @comment
+
+[
+  (string)
+  (template_string)
+  (template_literal_type)
+] @string
+
+(escape_sequence) @string.escape
+
+(regex) @string.regex
+(regex_flags) @keyword.regex
+(number) @number
+
+; Tokens
+
+[
+  "..."
+  "-"
+  "--"
+  "-="
+  "+"
+  "++"
+  "+="
+  "*"
+  "*="
+  "**"
+  "**="
+  "/"
+  "/="
+  "%"
+  "%="
+  "<"
+  "<="
+  "<<"
+  "<<="
+  "="
+  "=="
+  "==="
+  "!"
+  "!="
+  "!=="
+  "=>"
+  ">"
+  ">="
+  ">>"
+  ">>="
+  ">>>"
+  ">>>="
+  "~"
+  "^"
+  "&"
+  "|"
+  "^="
+  "&="
+  "|="
+  "&&"
+  "||"
+  "??"
+  "&&="
+  "||="
+  "??="
+] @operator
+
+(ternary_expression
+  [
+    "?"
+    ":"
+  ] @operator
+)
+
+[
+  ";"
+  "?."
+  "."
+  ","
+  ":"
+  "?"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+(template_substitution
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+(template_type
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+(type_arguments
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+
+(decorator "@" @punctuation.special)
+
+; Keywords
+
+[
+  "abstract"
+  "as"
+  "async"
+  "await"
+  "break"
+  "case"
+  "catch"
+  "class"
+  "const"
+  "continue"
+  "debugger"
+  "declare"
+  "default"
+  "delete"
+  "do"
+  "else"
+  "enum"
+  "export"
+  "extends"
+  "finally"
+  "for"
+  "from"
+  "function"
+  "get"
+  "if"
+  "implements"
+  "import"
+  "in"
+  "infer"
+  "instanceof"
+  "interface"
+  "is"
+  "keyof"
+  "let"
+  "namespace"
+  "new"
+  "of"
+  "override"
+  "private"
+  "protected"
+  "public"
+  "readonly"
+  "return"
+  "satisfies"
+  "set"
+  "static"
+  "switch"
+  "target"
+  "throw"
+  "try"
+  "type"
+  "typeof"
+  "using"
+  "var"
+  "void"
+  "while"
+  "with"
+  "yield"
+] @keyword
+
+(glimmer_opening_tag) @tag
+(glimmer_closing_tag) @tag
+
+(glimmer_template) ["<" "</" ">"] @punctuation.bracket

--- a/languages/glimmer_typescript/indents.scm
+++ b/languages/glimmer_typescript/indents.scm
@@ -1,0 +1,23 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/typescript
+[
+    (call_expression)
+    (assignment_expression)
+    (member_expression)
+    (lexical_declaration)
+    (variable_declaration)
+    (assignment_expression)
+    ; below handled by  `(_ "{" "}" @end) @indent`
+    ; (if_statement)
+    ; (for_statement)
+    ; (while_statement)
+] @indent
+
+(_ "[" "]" @end) @indent
+(_ "<" ">" @end) @indent
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent
+
+(glimmer_template
+  (glimmer_opening_tag)
+  (glimmer_closing_tag) @end
+) @indent

--- a/languages/glimmer_typescript/injections.scm
+++ b/languages/glimmer_typescript/injections.scm
@@ -1,0 +1,80 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/typescript
+(((comment) @_jsdoc_comment
+  (#match? @_jsdoc_comment "(?s)^/[*][*][^*].*[*]/$")) @injection.content
+  (#set! injection.language "jsdoc"))
+
+(((comment) @reference
+  (#match? @reference "^///\\s+<reference\\s+types=\"\\S+\"\\s*/>\\s*$")) @injection.content
+  (#set! injection.language "html"))
+
+((regex) @injection.content
+  (#set! injection.language "regex"))
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "css")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "css"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "html")
+  arguments: (template_string) @injection.content
+                              (#set! injection.language "html")
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "js")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "javascript"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "json")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "json"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "sql")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "sql"))
+)
+
+(call_expression
+  function: (identifier) @_name (#eq? @_name "ts")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "typescript"))
+)
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^ya?ml$")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "yaml"))
+)
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^g(raph)?ql$")
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "graphql"))
+)
+
+(call_expression
+  function: (identifier) @_name (#match? @_name "^g(raph)?ql$")
+  arguments: (arguments (template_string (string_fragment) @injection.content
+                              (#set! injection.language "graphql")))
+)
+
+; Parse Ember/Glimmer/Handlebars/HTMLBars/etc. template literals
+; e.g.: await render(hbs`<SomeComponent />`)
+(call_expression
+  function: ((identifier) @_name
+    (#eq? @_name "hbs"))
+  arguments: (template_string
+      (string_fragment) @injection.content
+      (#set! injection.language "Handlebars")))
+
+; Ember Unified <template> syntax
+; e.g.: <template><SomeComponent @arg={{double @value}} /></template>
+((glimmer_template
+  (raw_text) @injection.content)
+  (#set! injection.language "Handlebars"))

--- a/languages/glimmer_typescript/outline.scm
+++ b/languages/glimmer_typescript/outline.scm
@@ -1,0 +1,98 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/typescript
+(internal_module
+    "namespace" @context
+    name: (_) @name) @item
+
+(enum_declaration
+    "enum" @context
+    name: (_) @name) @item
+
+(type_alias_declaration
+    "type" @context
+    name: (_) @name) @item
+
+(function_declaration
+    "async"? @context
+    "function" @context
+    name: (_) @name
+    parameters: (formal_parameters
+      "(" @context
+      ")" @context)) @item
+
+(interface_declaration
+    "interface" @context
+    name: (_) @name) @item
+
+(export_statement
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (_) @name) @item))
+
+(program
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (_) @name) @item))
+
+(class_declaration
+    "class" @context
+    name: (_) @name) @item
+
+(abstract_class_declaration
+    "abstract" @context
+    "class" @context
+    name: (_) @name) @item
+
+(method_definition
+    [
+        "get"
+        "set"
+        "async"
+        "*"
+        "readonly"
+        "static"
+        (override_modifier)
+        (accessibility_modifier)
+    ]* @context
+    name: (_) @name
+    parameters: (formal_parameters
+      "(" @context
+      ")" @context)) @item
+
+(public_field_definition
+    [
+        "declare"
+        "readonly"
+        "abstract"
+        "static"
+        (accessibility_modifier)
+    ]* @context
+    name: (_) @name) @item
+
+; Add support for (node:test, bun:test and Jest) runnable
+(
+    (call_expression
+        function: [
+            (identifier) @_name
+            (member_expression
+                object: [
+                    (identifier) @_name
+                    (member_expression object: (identifier) @_name)
+                ]
+            )
+        ] @context
+        (#any-of? @_name "it" "test" "describe" "context" "suite")
+        arguments: (
+            arguments . (string (string_fragment) @name)
+        )
+    )
+) @item
+
+(comment) @annotation
+
+(class_body
+  (glimmer_template
+    (glimmer_opening_tag) @name
+  ) @item
+)

--- a/languages/glimmer_typescript/overrides.scm
+++ b/languages/glimmer_typescript/overrides.scm
@@ -1,0 +1,3 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/typescript
+(comment) @comment.inclusive
+(string) @string

--- a/languages/glimmer_typescript/runnables.scm
+++ b/languages/glimmer_typescript/runnables.scm
@@ -1,0 +1,22 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/typescript
+; Add support for (node:test, bun:test and Jest) runnable
+; Function expression that has `it`, `test` or `describe` as the function name
+(
+    (call_expression
+        function: [
+            (identifier) @_name
+            (member_expression
+                object: [
+                    (identifier) @_name
+                    (member_expression object: (identifier) @_name)
+                ]
+            )
+        ]
+        (#any-of? @_name "it" "test" "describe" "context" "suite" "module")
+        arguments: (
+            arguments . (string (string_fragment) @run)
+        )
+    ) @_js-test
+
+    (#set! tag js-test)
+)

--- a/languages/glimmer_typescript/textobjects.scm
+++ b/languages/glimmer_typescript/textobjects.scm
@@ -1,0 +1,80 @@
+; Manually copied from upstream: https://github.com/zed-industries/zed/tree/6cac0b33dcd9b6af04f9d8dd21c8fa00937af97c/crates/languages/src/typescript
+(comment)+ @comment.around
+
+(function_declaration
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(method_definition
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(function_expression
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(arrow_function
+    body: (statement_block
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(arrow_function) @function.around
+(function_signature) @function.around
+
+(generator_function
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(generator_function_declaration
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}")) @function.around
+
+(class_declaration
+    body: (_
+        "{"
+        [(_) ";"?]* @class.inside
+        "}" )) @class.around
+
+(class
+    body: (_
+        "{"
+        (_)* @class.inside
+        "}" )) @class.around
+
+(interface_declaration
+    body: (_
+        "{"
+        [(_) ";"?]* @class.inside
+        "}" )) @class.around
+
+(enum_declaration
+    body: (_
+        "{"
+        [(_) ","?]* @class.inside
+        "}" )) @class.around
+
+(ambient_declaration
+    (module
+    body: (_
+        "{"
+        [(_) ";"?]* @class.inside
+        "}" ))) @class.around
+
+(internal_module
+    body: (_
+        "{"
+        [(_) ";"?]* @class.inside
+        "}" )) @class.around
+
+(type_alias_declaration) @class.around


### PR DESCRIPTION
Duplicates Zed’s tree-sitter queries for JavaScript and TypeScript and extends injects handlebars into <template> tags and string literals (named `hbs`). There is a mismatch between our JavaScript grammar and Zed’s grammar, it seems like they are using TypeScript for both syntaxes? For now I commented out all invalid JavaScript queries.