### PR TITLE
Improve glimmer queries 

### DIFF
--- a/languages/glimmer/brackets.scm
+++ b/languages/glimmer/brackets.scm
@@ -1,0 +1,32 @@
+("{{" @open "}}" @close)
+("{{" @open "~}}" @close)
+("{{#" @open "}}" @close)
+("{{#" @open "~}}" @close)
+("{{~#" @open "}}" @close)
+("{{~#" @open "~}}" @close)
+("{{~" @open "~}}" @close)
+("{{~" @open "}}" @close)
+("{{/" @open "}}" @close)
+("{{/" @open "~}}" @close)
+("{{~/" @open "~}}" @close)
+("{{~/" @open "}}" @close)
+("(" @open ")" @close)
+("<" @open "/>" @close)
+("</" @open ">" @close)
+("<" @open ">" @close)
+("\"" @open "\"" @close)
+
+; Fixes auto indenting when pressing enter in-between two tags `<div>|</div>`
+(
+  (element_node
+    (element_node_start) @open
+    (element_node_end) @close
+  ) (#set! newline.only)
+)
+
+(
+  (block_statement
+    (block_statement_start) @open
+    (block_statement_end) @close
+  ) (#set! newline.only)
+)

--- a/languages/glimmer/config.toml
+++ b/languages/glimmer/config.toml
@@ -1,3 +1,8 @@
 name = "Handlebars"
 grammar = "glimmer"
 path_suffixes = ["hbs"]
+prettier_parser_name = "glimmer"
+brackets = [
+  { start = "{{", end = "}}", close = true, newline = true, not_in = ["comment", "string"] },
+  { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
+]

--- a/languages/glimmer/highlights.scm
+++ b/languages/glimmer/highlights.scm
@@ -1,3 +1,4 @@
+
 ; === Tag Names ===
 
 ; Tags that start with a lower case letter are HTML tags
@@ -8,81 +9,95 @@
 ((tag_name) @constructor
   (#match? @constructor "^[A-Z]"))
 
-(attribute_name) @property
-
+(attribute_name) @attribute
 (string_literal) @string
 (number_literal) @number
 (boolean_literal) @boolean
-
 (concat_statement) @string
+(comment_statement) @comment
 
 ; === Block Statements ===
 
-; Highlight the brackets
-(block_statement_start) @tag.delimiter
-(block_statement_end) @tag.delimiter
+(hash_pair
+  key: (identifier) @property)
 
-; Highlight `if`/`each`/`let`
-(block_statement_start path: (identifier) @conditional)
-(block_statement_end path: (identifier) @conditional)
-((mustache_statement (identifier) @conditional)
- (#match? @conditional "else"))
+; Start by making all identifiers as variabes
+(identifier) @variable
 
-; == Mustache Statements ===
+; Mark all paths e.g. (something.else) as properties
+(path_expression
+  (identifier) @property)
 
-; Hightlight the whole statement, to color brackets and separators
-(mustache_statement) @tag.delimiter
+; Mark first path identifier as a variable e.g. ([something].else)
+(path_expression
+  (identifier)+ @variable)
 
-; An identifier in a mustache expression is a variable
-((mustache_statement [
-  (path_expression (identifier) @variable)
-  (identifier) @variable
-  ])
-  (#not-match? @variable "yield|outlet|this|else"))
-; As are arguments in a block statement
-(block_statement_start argument: [
-  (path_expression (identifier) @variable)
-  (identifier) @variable
-  ])
-; As is an identifier in a block param
-(block_params (identifier) @variable)
-; As are helper arguments
-((helper_invocation argument: [
-  (path_expression (identifier) @variable)
-  (identifier) @variable
-  ])
-  (#not-match? @variable "this"))
-; `this` should be highlighted as a built-in variable
-((identifier) @variable.builtin
-  (#match? @variable.builtin "this"))
-
-; If the identifier is just "yield" or "outlet", it's a keyword
-((mustache_statement (identifier) @keyword)
-  (#match? @keyword "yield|outlet"))
+; Overrides all identifiers named `this`
+((identifier) @variable.special
+  (#eq? @variable.special "this"))
 
 ; Helpers are functions
-((helper_invocation helper: [
-  (path_expression (identifier) @function)
-  (identifier) @function
-  ])
-  (#not-match? @function "if|yield"))
-((helper_invocation helper: (identifier) @conditional)
-  (#match? @conditional "if"))
-((helper_invocation helper: (identifier) @keyword)
-  (#match? @keyword "yield"))
+(helper_invocation
+  helper: [
+    (path_expression (identifier) @function)
+    (identifier) @function
+  ]
+)
 
-(hash_pair key: (identifier) @property)
-
-(comment_statement) @comment
-
-(attribute_node "=" @operator)
-
-(block_params "as" @keyword)
-(block_params "|" @operator)
+((identifier) @keyword
+  (#any-of? @keyword
+    "yield"
+    "outlet"
+    "debugger"))
 
 [
   "<"
   ">"
   "</"
   "/>"
-] @tag.delimiter
+  "{{"
+  "}}"
+  "~}}"
+  "{{/"
+  "{{#"
+  "{{~#"
+  "{{~"
+  "{{~/"
+  ")"
+  "("
+] @punctuation.bracket
+
+"." @punctuation.delimiter
+"as" @keyword
+
+[
+  "="
+  "|"
+] @operator
+
+; classic component invocation
+(block_statement_start
+  path: (identifier) @constructor)
+(block_statement_end
+  path: (identifier) @constructor)
+
+; Override for built-in keywords
+(
+  [
+    (block_statement_start path: (identifier) @keyword)
+    (block_statement_end path: (identifier) @keyword)
+  ]
+  (#any-of? @keyword
+    "each"
+    "each-in"
+    "unless"
+    "with"
+    "in-element"
+    "let"
+    "if"
+  )
+)
+
+(mustache_statement
+	(identifier) @keyword
+	(#eq? @keyword "else"))

--- a/languages/glimmer/indents.scm
+++ b/languages/glimmer/indents.scm
@@ -1,22 +1,28 @@
-[
-   (element_node (element_node_start))
-   (element_node_void)
-   (block_statement (block_statement_start))
-   (mustache_statement)
- ] @indent.begin
+; Angle bracket elements
+(element_node
+  (element_node_start) @start
+  (element_node_end)? @end) @indent
 
- (element_node (element_node_end  [">"] @indent.end))
- (element_node_void "/>" @indent.end)
- [
-  ">"
-  "/>"
-  "</"
-   "{{/"
-   "}}"
-  ] @indent.branch
+; Mustache blocks
+(block_statement
+  (block_statement_start) @start
+  (block_statement_end)? @end) @indent
 
- (mustache_statement
-   (helper_invocation helper: (identifier) @_identifier (#lua-match? @_identifier "else"))
-   ) @indent.branch
- (mustache_statement ((identifier) @_identifier (#lua-match? @_identifier "else"))) @indent.branch
- (comment_statement) @indent.ignore
+; Matches `else if` statements
+(block_statement
+	(mustache_statement
+		(helper_invocation
+			helper: (identifier) @_identifier (#match? @_identifier "else")
+			argument: (identifier) @_argIdentifier (#match? @_argIdentifier "if"))
+	) @start
+) @indent
+
+; Matches `else` statements
+(block_statement
+	(mustache_statement
+		(
+      (identifier) @_identifier
+      (#match? @_identifier "else")
+    )
+	) @start
+) @indent


### PR DESCRIPTION
Updated queries for glimmer: 

* Simplified queries and updated captures to supported Zed captures.
* Highlight properties and variables correctly
* Highlight classic components the same way as angle bracket components
* Added support for brackets highlighting

Before:
<img width="1792" alt="Screenshot 2025-03-19 at 09 56 48" src="https://github.com/user-attachments/assets/fbc43804-0307-4c30-9e18-26310b4fdb7b" />

After:
<img width="1792" alt="Screenshot 2025-03-19 at 09 55 56" src="https://github.com/user-attachments/assets/d127017c-e7fa-4161-8b7b-94e35427b850" />
